### PR TITLE
release v1.1.0 (#5)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    # default is / which breaks drone
+    pull-request-branch-name:
+      separator: "-"
+    # not created automatically for version updates so only security ones are created
+    # https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file
+    open-pull-requests-limit: 0 
+    

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM python:3.7
+FROM python:3.9
 
 WORKDIR /program
 

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2022 onetask.ai GmbH
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.9
 
 WORKDIR /app
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ Jinja2==3.0.2
 jsonschema==4.2.1
 MarkupSafe==2.0.1
 mypy-extensions==0.4.3
-numpy==1.21.4
+numpy==1.22.0
 pandas==1.3.4
 pathspec==0.9.0
 platformdirs==2.4.0

--- a/start
+++ b/start
@@ -14,7 +14,7 @@ docker run -d --rm \
 --name refinery-weak-supervisor \
 -p 7054:80 \
 -e POSTGRES=postgresql://postgres:onetask@graphql-postgres:5432 \
--e WS_NOTIFY_ENDPOINT="http://ws-notify:8080" \
+-e WS_NOTIFY_ENDPOINT="http://refinery-websocket:8080" \
 --mount type=bind,source="$(pwd)"/,target=/app \
 -v /var/run/docker.sock:/var/run/docker.sock \
 --network dev-setup_default \


### PR DESCRIPTION
* Update LICENSE

* changes old service names to new ones

* Create dependabot.yml

* Bump numpy from 1.21.4 to 1.22.0

Bumps [numpy](https://github.com/numpy/numpy) from 1.21.4 to 1.22.0.
- [Release notes](https://github.com/numpy/numpy/releases)
- [Changelog](https://github.com/numpy/numpy/blob/main/doc/RELEASE_WALKTHROUGH.rst)
- [Commits](https://github.com/numpy/numpy/compare/v1.21.4...v1.22.0)

---
updated-dependencies:
- dependency-name: numpy dependency-type: direct:production ...

Signed-off-by: dependabot[bot] <support@github.com>

* bump python to 3.9

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: felix0496 <felix.kirsch@kern.ai>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>