### PR TITLE
Weak Supervision without manual labels 

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI, HTTPException, responses, status
 from pydantic import BaseModel
+from typing import Union, Dict, Optional
 
 from controller import stats
 from controller import integration
@@ -14,6 +15,7 @@ class WeakSupervisionRequest(BaseModel):
     labeling_task_id: str
     user_id: str
     weak_supervision_task_id: str
+    overwrite_weak_supervision: Optional[Union[float, Dict[str, float]]]
 
 
 class TaskStatsRequest(BaseModel):
@@ -31,6 +33,7 @@ class SourceStatsRequest(BaseModel):
 class ExportWsStatsRequest(BaseModel):
     project_id: str
     labeling_task_id: str
+    overwrite_weak_supervision: Optional[Union[float, Dict[str, float]]]
 
 
 @app.post("/fit_predict")
@@ -43,6 +46,7 @@ def weakly_supervise(
         request.labeling_task_id,
         request.user_id,
         request.weak_supervision_task_id,
+        request.overwrite_weak_supervision,
     )
     general.remove_and_refresh_session(session_token)
     return responses.PlainTextResponse(status_code=status.HTTP_200_OK)
@@ -80,7 +84,7 @@ def calculate_source_stats(
 def export_ws_stats(request: ExportWsStatsRequest) -> responses.PlainTextResponse:
     session_token = general.get_ctx_token()
     status_code, message = integration.export_weak_supervision_stats(
-        request.project_id, request.labeling_task_id
+        request.project_id, request.labeling_task_id, request.overwrite_weak_supervision
     )
     general.remove_and_refresh_session(session_token)
 

--- a/controller/integration.py
+++ b/controller/integration.py
@@ -29,7 +29,7 @@ def __create_quality_metrics(
     project_id: str,
     labeling_task_id: str,
     overwrite_weak_supervision: Union[float, Dict[str, float]],
-) -> Dict[Any, Any]:
+) -> Dict[Tuple[str, str], Dict[str, float]]:
     if isinstance(overwrite_weak_supervision, float):
         ws_weights = {}
         for heuristic_id in information_source.get_all_ids_by_labeling_task_id(
@@ -54,7 +54,7 @@ def fit_predict(
     labeling_task_id: str,
     user_id: str,
     weak_supervision_task_id: str,
-    overwrite_weak_supervision: Optional[Dict[Any, Any]] = None,
+    overwrite_weak_supervision: Optional[Union[float, Dict[str, float]]] = None,
 ):
     quality_metrics_overwrite = None
     if overwrite_weak_supervision is not None:
@@ -146,7 +146,8 @@ def export_weak_supervision_stats(
 
 
 def integrate_classification(
-    df: pd.DataFrame, quality_metrics_overwrite: Dict[Any, Any] = None
+    df: pd.DataFrame,
+    quality_metrics_overwrite: Optional[Dict[Tuple[str, str], Dict[str, float]]] = None,
 ):
     cnlm = util.get_cnlm_from_df(df)
     weak_supervision_results = cnlm.weakly_supervise(quality_metrics_overwrite)
@@ -162,7 +163,8 @@ def integrate_classification(
 
 
 def integrate_extraction(
-    df: pd.DataFrame, quality_metrics_overwrite: Dict[Any, Any] = None
+    df: pd.DataFrame,
+    quality_metrics_overwrite: Optional[Dict[Tuple[str, str], Dict[str, float]]] = None,
 ):
     enlm = util.get_enlm_from_df(df)
     weak_supervision_results = enlm.weakly_supervise(quality_metrics_overwrite)

--- a/controller/integration.py
+++ b/controller/integration.py
@@ -159,9 +159,9 @@ def integrate_classification(df: pd.DataFrame, stats_lkp: Dict[Any, Any] = None)
     return return_values
 
 
-def integrate_extraction(df: pd.DataFrame):
+def integrate_extraction(df: pd.DataFrame, stats_lkp: Dict[Any, Any] = None):
     enlm = util.get_enlm_from_df(df)
-    weak_supervision_results = enlm.weakly_supervise()
+    weak_supervision_results = enlm.weakly_supervise(stats_lkp)
     return_values = defaultdict(list)
     for record_id, preds in weak_supervision_results.items():
         for pred in preds:

--- a/controller/integration.py
+++ b/controller/integration.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Tuple, Optional, Union
 import traceback
 import pandas as pd
 import pickle
@@ -18,19 +18,62 @@ from submodules.model.business_objects import (
     labeling_task,
     record_label_association,
     weak_supervision,
+    labeling_task_label,
+    information_source,
 )
+
+NO_LABEL_WS_PRECISION = 0.8
+
+
+def __create_stats_lkp(
+    project_id: str,
+    labeling_task_id: str,
+    overwrite_weak_supervision: Union[float, Dict[str, float]],
+) -> Dict[Any, Any]:
+    if isinstance(overwrite_weak_supervision, float):
+        ws_weights = {}
+        for heuristic_id in information_source.get_all_ids_by_labeling_task_id(
+            project_id, labeling_task_id
+        ):
+            ws_weights[str(heuristic_id)] = overwrite_weak_supervision
+    else:
+        ws_weights = overwrite_weak_supervision
+
+    ws_stats = {}
+    for heuristic_id in ws_weights:
+        label_ids = labeling_task_label.get_all_ids(project_id, labeling_task_id)
+        for (label_id,) in label_ids:
+            ws_stats[(heuristic_id, str(label_id))] = {
+                "precision": ws_weights[heuristic_id]
+            }
+    return ws_stats
 
 
 def fit_predict(
-    project_id: str, labeling_task_id: str, user_id: str, weak_supervision_task_id: str
+    project_id: str,
+    labeling_task_id: str,
+    user_id: str,
+    weak_supervision_task_id: str,
+    overwrite_weak_supervision: Optional[Dict[Any, Any]] = None,
 ):
+    stats_lkp = None
+    if overwrite_weak_supervision is not None:
+        stats_lkp = __create_stats_lkp(
+            project_id, labeling_task_id, overwrite_weak_supervision
+        )
+    elif not record_label_association.is_any_record_manually_labeled_by_lt_id(
+        project_id, labeling_task_id
+    ):
+        stats_lkp = __create_stats_lkp(
+            project_id, labeling_task_id, NO_LABEL_WS_PRECISION
+        )
+
     task_type, df = collect_data(project_id, labeling_task_id, True)
     try:
         if task_type == enums.LabelingTaskType.CLASSIFICATION.value:
-            results = integrate_classification(df)
-
+            results = integrate_classification(df, stats_lkp)
         else:
-            results = integrate_extraction(df)
+            results = integrate_extraction(df, stats_lkp)
         weak_supervision.store_data(
             project_id,
             labeling_task_id,
@@ -52,46 +95,59 @@ def fit_predict(
 
 
 def export_weak_supervision_stats(
-    project_id: str, labeling_task_id: str
+    project_id: str,
+    labeling_task_id: str,
+    overwrite_weak_supervision: Optional[Union[float, Dict[str, float]]] = None,
 ) -> Tuple[int, str]:
+    if overwrite_weak_supervision is not None:
+        ws_stats = __create_stats_lkp(
+            project_id, labeling_task_id, overwrite_weak_supervision
+        )
+    elif not record_label_association.is_any_record_manually_labeled_by_lt_id(
+        project_id, labeling_task_id
+    ):
+        ws_stats = __create_stats_lkp(
+            project_id, labeling_task_id, NO_LABEL_WS_PRECISION
+        )
+    else:
+        task_type, df = collect_data(project_id, labeling_task_id, False)
+        try:
+            if task_type == enums.LabelingTaskType.CLASSIFICATION.value:
+                cnlm = util.get_cnlm_from_df(df)
+                stats_df = cnlm.quality_metrics()
+            elif task_type == enums.LabelingTaskType.INFORMATION_EXTRACTION.value:
+                enlm = util.get_enlm_from_df(df)
+                stats_df = enlm.quality_metrics()
+            else:
+                return 404, f"Task type {task_type} not implemented"
 
-    task_type, df = collect_data(project_id, labeling_task_id, False)
-    try:
-        if task_type == enums.LabelingTaskType.CLASSIFICATION.value:
-            cnlm = util.get_cnlm_from_df(df)
-            stats_df = cnlm.quality_metrics()
-        elif task_type == enums.LabelingTaskType.INFORMATION_EXTRACTION.value:
-            enlm = util.get_enlm_from_df(df)
-            stats_df = enlm.quality_metrics()
-        else:
-            return 404, f"Task type {task_type} not implemented"
+            if len(stats_df) != 0:
+                ws_stats = stats_df.set_index(["identifier", "label_name"]).to_dict(
+                    orient="index"
+                )
+            else:
+                return 404, "Can't compute weak supervision"
 
-        if len(stats_df) != 0:
-            stats_lkp = stats_df.set_index(["identifier", "label_name"]).to_dict(
-                orient="index"
-            )
-        else:
-            return 404, "Can't compute weak supervision"
+        except Exception:
+            print(traceback.format_exc(), flush=True)
+            general.rollback()
+            return 500, "Internal server error"
 
-        os.makedirs(os.path.join("/inference", project_id), exist_ok=True)
-        with open(
-            os.path.join(
-                "/inference", project_id, f"weak-supervision-{labeling_task_id}.pkl"
-            ),
-            "wb",
-        ) as f:
-            pickle.dump(stats_lkp, f)
+    os.makedirs(os.path.join("/inference", project_id), exist_ok=True)
+    with open(
+        os.path.join(
+            "/inference", project_id, f"weak-supervision-{labeling_task_id}.pkl"
+        ),
+        "wb",
+    ) as f:
+        pickle.dump(ws_stats, f)
 
-    except Exception:
-        print(traceback.format_exc(), flush=True)
-        general.rollback()
-        return 500, "Internal server error"
     return 200, "OK"
 
 
-def integrate_classification(df: pd.DataFrame):
+def integrate_classification(df: pd.DataFrame, stats_lkp: Dict[Any, Any] = None):
     cnlm = util.get_cnlm_from_df(df)
-    weak_supervision_results = cnlm.weakly_supervise()
+    weak_supervision_results = cnlm.weakly_supervise(stats_lkp)
     return_values = defaultdict(list)
     for record_id, (
         label_id,
@@ -128,12 +184,12 @@ def collect_data(
 
     query_results = []
     if labeling_task_item.task_type == enums.LabelingTaskType.CLASSIFICATION.value:
-        for information_source in labeling_task_item.information_sources:
-            if only_selected and not information_source.is_selected:
+        for information_source_item in labeling_task_item.information_sources:
+            if only_selected and not information_source_item.is_selected:
                 continue
             results = (
                 record_label_association.get_all_classifications_for_information_source(
-                    project_id, information_source.id
+                    project_id, information_source_item.id
                 )
             )
             query_results.extend(results)
@@ -149,11 +205,11 @@ def collect_data(
         labeling_task_item.task_type
         == enums.LabelingTaskType.INFORMATION_EXTRACTION.value
     ):
-        for information_source in labeling_task_item.information_sources:
-            if only_selected and not information_source.is_selected:
+        for information_source_item in labeling_task_item.information_sources:
+            if only_selected and not information_source_item.is_selected:
                 continue
             results = record_label_association.get_all_extraction_tokens_for_information_source(
-                project_id, information_source.id
+                project_id, information_source_item.id
             )
             query_results.extend(results)
 

--- a/controller/integration.py
+++ b/controller/integration.py
@@ -61,7 +61,7 @@ def fit_predict(
         stats_lkp = __create_stats_lkp(
             project_id, labeling_task_id, overwrite_weak_supervision
         )
-    elif not record_label_association.is_any_record_manually_labeled_by_lt_id(
+    elif not record_label_association.is_any_record_manually_labeled(
         project_id, labeling_task_id
     ):
         stats_lkp = __create_stats_lkp(
@@ -103,7 +103,7 @@ def export_weak_supervision_stats(
         ws_stats = __create_stats_lkp(
             project_id, labeling_task_id, overwrite_weak_supervision
         )
-    elif not record_label_association.is_any_record_manually_labeled_by_lt_id(
+    elif not record_label_association.is_any_record_manually_labeled(
         project_id, labeling_task_id
     ):
         ws_stats = __create_stats_lkp(

--- a/requirements.txt
+++ b/requirements.txt
@@ -107,5 +107,5 @@ urllib3==1.26.16
     #   requests
 uvicorn==0.22.0
     # via -r requirements/common-requirements.txt
-weak-nlp==0.0.12
+weak-nlp==0.0.13
     # via -r requirements/requirements.in

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,2 +1,2 @@
 -r common-requirements.txt
-weak-nlp==0.0.12
+weak-nlp==0.0.13


### PR DESCRIPTION
This is the main PR, related PRs are:
- https://github.com/code-kern-ai/refinery-submodule-model/pull/57
- https://github.com/code-kern-ai/refinery-gateway/pull/160
- https://github.com/code-kern-ai/gates-gateway/pull/32
- https://github.com/code-kern-ai/weak-nlp/pull/7

This PR implements changes to run the weak supervision without setting manual labels for the labeling task. Instead of the calculated precision values for each heuristic, custom values can be applied.
In more detail:
1. If no manual labels are set, all heuristics get the same default precision, which defaults to 0.8.
2. This precision can be overwritten and set to another value. If so, it is also applied if any manual labels are set.
3. For every heuristic a precision can be set. This also overwrites calculated precision if manual labels are set.

For testing, the weak-supervisor has to be started excluded and setup to work with a local installation of the weak-nlp package (Copy weak-nlp into weak-supervisor, uncomment line for local installation from dev.Dockerfile).
The other services can be started with the dev-setup `bash start -b ws-no-manual -e refinery-weak-supervisor`

2 GraphQL endpoints are changed:
- initiateWeakSupervisionByProjectId
It has now two additional optional arguments: `overwriteDefaultPrecision` and `overwriteWeakSupervision`. `overwriteDefaultPrecision` applies the same precision to all heuristics, it overwrites the calculated precision if existing. It expects a float value.
`overwriteWeakSupervision` can be used to set a distinct precision for each heuristic. It expects a dictionary with the following structure:
```
{
  "<labeling_task_id>": {
      "<heuristic_id>": "<precision>",
      "<heuristic_id>": "<precision>",
     ...
  },
  ...
}
```
If both arguments are given, only `overwriteWeakSupervision` is applied.

- runHeuristicThenTriggerWeakSupervision
The same optional arguments are added. `overwriteDefaultPrecision` works the same as above.
`overwriteWeakSupervision` only expects a subset of the dictionary from above as the endpoint is labeling task specific:
```
{
    "<heuristic_id>": "<precision>",
    "<heuristic_id>": "<precision>",
     ...
}
```

The endpoint for starting a gates runtime also changed, here only one optional argument was added.
```
class ApiConfigRequest(BaseModel):
    heuristics: List[str]
    similarity_search: Optional[List[str]] = None
    overwrite_weak_supervision: Optional[Dict[str, Any]] = None
```
`overwrite_weak_supervision` combines the both arguments for the graphql endpoints, either a float or a dictionary can be provided. The dictionary must have the same structure as for the `initiateWeakSupervisionByProjectId` endpoint, as a gates runtime could handle multiple labeling tasks.


<details><summary>GraphQL Example 1</summary>

```mutation {
  initiateWeakSupervisionByProjectId(
    projectId: "328d7d12-b0d3-4874-9e73-4a53a28d0536",
    overwriteDefaultPrecision: 0.5,
    overwriteWeakSupervision: "{\"2dfe75be-4c9f-4bbc-9a5e-2878ec160fe1\":{\"2c3fecf5-7b02-417a-a1eb-86c1d368d7a9\": 1, \"381c7d6a-6deb-47fe-925a-b5e068d81c95\": 0, \"e0051dcd-b878-4c00-a47f-21c72d33aff3\": 0} }"
  ) {
    ok
  }
}
```

In this case `overwriteWeakSupervision` overwrites the `overwriteDefaultPrecision` argument as it is more specific.
</details> 
<details><summary>GraphQL Example 2</summary>

```mutation {
  runHeuristicThenTriggerWeakSupervision(
    projectId: "328d7d12-b0d3-4874-9e73-4a53a28d0536",
    informationSourceId: "2c3fecf5-7b02-417a-a1eb-86c1d368d7a9",
    labelingTaskId: "2dfe75be-4c9f-4bbc-9a5e-2878ec160fe1",
    overwriteDefaultPrecision: 0
  ) {
    ok
  }
}
```

</details>